### PR TITLE
fix crashing with :badarg on a discovereable relative protocol url

### DIFF
--- a/lib/oembed/providers/discoverable_provider.ex
+++ b/lib/oembed/providers/discoverable_provider.ex
@@ -27,10 +27,11 @@ defmodule OEmbed.DiscoverableProvider do
 
   defp discover(url) do
     with {:ok, %HTTPoison.Response{body: html}} <- HTTPoison.get(url, [], [follow_redirect: true, ssl: [{:versions, [:'tlsv1.2']}]]),
-      [_ | _] = tags <- Floki.find(html, "head link[type='application/json+oembed']"),
-       {"link", attributes, _} <- List.first(tags),
-       %{"href" => href} <- Enum.into(attributes, %{}) do
-        {:ok, href}
+         [_ | _] = tags <- Floki.find(html, "head link[type='application/json+oembed']"),
+         {"link", attributes, _} <- List.first(tags),
+         %{"href" => href} <- Enum.into(attributes, %{})
+    do
+      {:ok, String.replace(href, ~r{^//}, "http://")}
     else
       _ -> {:error, "oEmbed url not found"}
     end


### PR DESCRIPTION
HTTPoison crashes with :badarg if provided url has double slash relative protocol ("//example.com")

So if some service provides discoverable oembed link with relative protocol, :get_oembed request will crash

Example:
```
<link rel="alternate" type="application/json+oembed" href="//www.playbuzz.com/api/oembed/?url=https://www.playbuzz.com/qzeyrr10/plan-a-vacation-and-well-tell-you-what-job-you-should-have&amp;format=json">
```

This fixes it by replacing // with http://. As random website may not use https, i figure replacing with http is more robust