### PR TITLE
update floki and use explicit parsing of floki

### DIFF
--- a/lib/oembed/providers/discoverable_provider.ex
+++ b/lib/oembed/providers/discoverable_provider.ex
@@ -26,12 +26,16 @@ defmodule OEmbed.DiscoverableProvider do
   end
 
   defp discover(url) do
-    with {:ok, %HTTPoison.Response{body: html}} <- HTTPoison.get(url, [], [follow_redirect: true, ssl: [{:versions, [:'tlsv1.2']}]]),
-         [_ | _] = tags <- Floki.find(html, "head link[type$='json+oembed']"),
+    with {:ok, %HTTPoison.Response{body: html}} <-
+           HTTPoison.get(url, [], follow_redirect: true, ssl: [{:versions, [:"tlsv1.2"]}]),
+         [_ | _] = tags <-
+           html
+           |> Floki.parse_document()
+           |> elem(1)
+           |> Floki.find("head link[type$='json+oembed']"),
          {"link", attributes, _} <- List.first(tags),
          %{"href" => href} <- Enum.into(attributes, %{}),
-         oembed_url = %URI{} <- URI.merge(url, href)
-    do
+         oembed_url = %URI{} <- URI.merge(url, href) do
       {:ok, URI.to_string(oembed_url)}
     else
       _ -> {:error, "oEmbed url not found"}

--- a/lib/oembed/providers/pinterest_provider.ex
+++ b/lib/oembed/providers/pinterest_provider.ex
@@ -19,22 +19,30 @@ defmodule OEmbed.PinterestProvider do
   def get(url) do
     case get_page_type(url) do
       {:ok, "pin"} ->
-        oembed = Rich.new(%{
-          html: get_pin_html(url)
-        })
+        oembed =
+          Rich.new(%{
+            html: get_pin_html(url)
+          })
+
         {:ok, oembed}
+
       _ ->
         {:error, "Error getting oEmbed"}
     end
   end
 
   defp get_page_type(url) do
-    with {:ok, %HTTPoison.Response{body: html}} <- HTTPoison.get(url, [], [follow_redirect: true, ssl: [{:versions, [:'tlsv1.2']}]]),
-      [_ | _] = tags <- Floki.find(html, "head meta[property='og:type']"),
-       {"meta", attributes, _} <- List.first(tags),
-       %{"content" => content} <- Enum.into(attributes, %{}),
-       %{"type" => type} <- Regex.named_captures(~r/^pinterestapp\:(?<type>.+)/, content) do
-        {:ok, type}
+    with {:ok, %HTTPoison.Response{body: html}} <-
+           HTTPoison.get(url, [], follow_redirect: true, ssl: [{:versions, [:"tlsv1.2"]}]),
+         [_ | _] = tags <-
+           html
+           |> Floki.parse_document()
+           |> elem(1)
+           |> Floki.find("head meta[property='og:type']"),
+         {"meta", attributes, _} <- List.first(tags),
+         %{"content" => content} <- Enum.into(attributes, %{}),
+         %{"type" => type} <- Regex.named_captures(~r/^pinterestapp\:(?<type>.+)/, content) do
+      {:ok, type}
     else
       _ -> {:error, "Error getting page type"}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule OEmbed.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:httpoison, ">= 0.9.0"},
-     {:floki, ">= 0.9.0"},
+     {:floki, ">= 0.24.0"},
      {:poison, ">= 1.5.0"},
      {:exconstructor, ">= 1.0.0"},
      {:exvcr, "~> 0.9", only: :test},


### PR DESCRIPTION
Since the update of Floki to version 0.24.0 other projects get warnings
in there tests when using Floki 0.24.0 and oembed together. With this
commit the warnings will disapear because it uses the new parse_*/1
functions instead of the old Floki.parse/1 that is now depricated.