### PR TITLE
Call the youtube oembed with https

### DIFF
--- a/fixture/vcr_cassettes/youtu_be_invalid.json
+++ b/fixture/vcr_cassettes/youtu_be_invalid.json
@@ -13,7 +13,7 @@
         }
       },
       "request_body": "",
-      "url": "http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fyoutu.be%2Finvalid__id"
+      "url": "https://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fyoutu.be%2Finvalid__id"
     },
     "response": {
       "binary": false,

--- a/fixture/vcr_cassettes/youtu_be_valid.json
+++ b/fixture/vcr_cassettes/youtu_be_valid.json
@@ -13,7 +13,7 @@
         }
       },
       "request_body": "",
-      "url": "http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ"
+      "url": "https://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ"
     },
     "response": {
       "binary": false,

--- a/fixture/vcr_cassettes/youtube_invalid.json
+++ b/fixture/vcr_cassettes/youtube_invalid.json
@@ -13,7 +13,7 @@
         }
       },
       "request_body": "",
-      "url": "http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dinvalid_id"
+      "url": "https://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dinvalid_id"
     },
     "response": {
       "binary": false,

--- a/fixture/vcr_cassettes/youtube_playlist_invalid.json
+++ b/fixture/vcr_cassettes/youtube_playlist_invalid.json
@@ -13,7 +13,7 @@
         }
       },
       "request_body": "",
-      "url": "http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fplaylist%3Flist%3Dinvalid_list"
+      "url": "https://www.youtube.com/oembed?format=json&url=https%2A%2F%2Fwww.youtube.com%2Fplaylist%3Flist%3Dinvalid_list"
     },
     "response": {
       "binary": false,

--- a/fixture/vcr_cassettes/youtube_playlist_valid.json
+++ b/fixture/vcr_cassettes/youtube_playlist_valid.json
@@ -13,7 +13,7 @@
         }
       },
       "request_body": "",
-      "url": "http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fplaylist%3Flist%3DPL634F2B56B8C346A2"
+      "url": "https://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fplaylist%3Flist%3DPL634F2B56B8C346A2"
     },
     "response": {
       "binary": false,

--- a/fixture/vcr_cassettes/youtube_valid.json
+++ b/fixture/vcr_cassettes/youtube_valid.json
@@ -13,7 +13,7 @@
         }
       },
       "request_body": "",
-      "url": "http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ"
+      "url": "https://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ"
     },
     "response": {
       "binary": false,

--- a/lib/oembed/providers/youtube_provider.ex
+++ b/lib/oembed/providers/youtube_provider.ex
@@ -4,7 +4,7 @@ defmodule OEmbed.YoutubeProvider do
   """
   use OEmbed.Provider
 
-  @oembed_endpoint "http://www.youtube.com/oembed?format=json&url="
+  @oembed_endpoint "https://www.youtube.com/oembed?format=json&url="
 
   @doc """
   Check if this provider supports given URL.


### PR DESCRIPTION
When doing calls with http some returned a 403 with error message:

```json
{
  "error": {
    "code": 403,
    "message": "SSL is required to perform this operation.",
    "status": "PERMISSION_DENIED"
  }
}
```

With https this error dissapeard.