### PR TITLE
Fix warnings, fixes #40

### DIFF
--- a/lib/oembed/resource.ex
+++ b/lib/oembed/resource.ex
@@ -21,7 +21,7 @@ defmodule OEmbed.Resource do
         thumbnail_height: nil
       ]
 
-      defstruct @common_keys ++ @keys
+      defstruct Keyword.merge(@common_keys, @keys)
 
       use ExConstructor
     end

--- a/lib/oembed/resources/link.ex
+++ b/lib/oembed/resources/link.ex
@@ -5,7 +5,5 @@ defmodule OEmbed.Link do
 
   @keys [type: "link"]
 
-  @requred_keys []
-
   use OEmbed.Resource
 end

--- a/lib/oembed/resources/photo.ex
+++ b/lib/oembed/resources/photo.ex
@@ -5,7 +5,5 @@ defmodule OEmbed.Photo do
 
   @keys [type: "photo", url: nil, width: nil, height: nil]
 
-  @requred_keys [:url, :width, :height]
-
   use OEmbed.Resource
 end

--- a/lib/oembed/resources/rich.ex
+++ b/lib/oembed/resources/rich.ex
@@ -5,7 +5,5 @@ defmodule OEmbed.Rich do
 
   @keys [type: "rich", html: nil, width: nil, height: nil]
 
-  @requred_keys [:html, :width, :height]
-
   use OEmbed.Resource
 end

--- a/lib/oembed/resources/video.ex
+++ b/lib/oembed/resources/video.ex
@@ -5,7 +5,5 @@ defmodule OEmbed.Video do
 
   @keys [type: "video", html: nil, width: nil, height: nil]
 
-  @requred_keys [:html, :width, :height]
-
   use OEmbed.Resource
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule OEmbed.Mixfile do
     [
       app: :oembed,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -22,7 +22,6 @@ defmodule OEmbed.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:httpoison, :exconstructor],
       extra_applications: [:logger],
       env: [providers: []]
     ]


### PR DESCRIPTION
This fixes all warnings on Elixir 1.11.

1. "duplicate key" warnings fixed by using `Keyword.merge/2` instead of `++`
2. "module attribute never used" fixed by just removing `@required_keys` from each of the resource types. I can understand why they're probably there, but until they're used, removing them makes sense.
3. Finally while running `mix test` directly from the repo there were additional warnings about applications being referenced but not depended on (floki, poison). That was fixed by just removing the `:applications` key from mix.exs. When this key isn't present a default application is now used that starts all dependencies automatically.