### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,4 @@
+# Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
@@ -19,5 +19,11 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-# Ignore Mix lock file
+# Ignore package tarball (built via "mix hex.build").
+oembed-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# Ignore Mix lock file.
 mix.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [0.4.1] - 2021-01-14
 ### Fixed
 - Call the youtube oembed with https ([@fatboypunk](https://github.com/fatboypunk))
@@ -29,7 +34,7 @@
 
 ## [0.1.1] - 2017-03-08
 ### Fixed
-- Fix crashing when URL is empty or nil. 
+- Fix crashing when URL is empty or nil.
 
 ## [0.1.0] - 2017-02-25
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2017 Sergey Storchay
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # OEmbed
 
 [![CI](https://github.com/r8/elixir-oembed/workflows/CI/badge.svg)](https://github.com/r8/elixir-oembed/actions?query=workflow%3ACI)
-[![Hex.pm](https://img.shields.io/hexpm/v/oembed.svg?style=flat-square)](https://hex.pm/packages/oembed)
-[![Hex.pm](https://img.shields.io/hexpm/dt/oembed.svg?style=flat-square)](https://hex.pm/packages/oembed)
+[![Module Version](https://img.shields.io/hexpm/v/oembed.svg?style=flat-square)](https://hex.pm/packages/oembed)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg?style=flat-square)](https://hexdocs.pm/oembed/)
+[![Total Download](https://img.shields.io/hexpm/dt/oembed.svg?style=flat-square)](https://hex.pm/packages/oembed)
+[![License](https://img.shields.io/hexpm/l/oembed.svg?style=flat-square)](https://github.com/r8/elixir-oembed/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/r8/elixir-oembed.svg?style=flat-square)](https://github.com/r8/elixir-oembed/commits/master)
 
 oEmbed consumer library for Elixir applications.
 
@@ -20,11 +23,13 @@ Among them:
 
 ## Installation
 
-Add `oembed` to your list of dependencies in `mix.exs`:
+Add `:oembed` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:oembed, "~> 0.4.1"}]
+  [
+    {:oembed, "~> 0.4.1"}
+  ]
 end
 ```
 
@@ -41,3 +46,10 @@ You can implement modules that support provider behaviour and add them to the pr
 ```elixir
 config :oembed, :providers, [MyApp.OEmbed.SomeProvider, MyApp.OEmbed.SomeOtherProvider]
 ```
+
+## Copyright and License
+
+Copyright (c) 2017 Sergey Storchay
+
+Released under the MIT License, which can be found in the repository in
+[LICENSE.md](./LICENSE.md).

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule OEmbed.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/r8/elixir-oembed"
   @version "0.4.1"
 
   def project do
@@ -10,16 +11,12 @@ defmodule OEmbed.Mixfile do
       elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      description: description(),
       package: package(),
       docs: docs(),
       deps: deps()
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     [
       extra_applications: [:logger],
@@ -27,15 +24,6 @@ defmodule OEmbed.Mixfile do
     ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:my_dep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
       {:httpoison, ">= 0.9.0"},
@@ -52,24 +40,27 @@ defmodule OEmbed.Mixfile do
 
   defp docs do
     [
+      extras: [
+        "CHANGELOG.md": [title: "Changelog"],
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
       source_url: "https://github.com/r8/elixir-oembed",
       source_ref: "v#{@version}",
-      main: "readme",
-      extras: ["README.md"]
+      formatters: ["html"]
     ]
-  end
-
-  defp description do
-    """
-    oEmbed consumer library for Elixir applications.
-    """
   end
 
   defp package do
     [
+      description: "oEmbed consumer library for Elixir applications.",
       maintainers: ["Sergey Storchay"],
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/r8/elixir-oembed"}
+      links: %{
+        "Changelog" => "https://hexodcs.pm/oembed/changelog.html",
+        "Github" => @source_url
+      }
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.